### PR TITLE
Demonstrate the pointlessness of nextVal().

### DIFF
--- a/test.js
+++ b/test.js
@@ -19,6 +19,10 @@ test('nextVal', (t) => {
   t.equal(utils.nextVal('1', m), '2')
   t.equal(utils.nextVal('3', m), null)
 
+  m.set('3', '1')
+  t.equal(utils.nextVal(utils.firstVal(m), m), '2')
+  t.equal(utils.nextVal(utils.lastVal(m), m), null)
+
   const s = new Set()
   t.equal(utils.nextVal(null, s), null)
   s.add('1')


### PR DESCRIPTION
nextVal() does not make sense with Map. It performs a full Map scan
every time it is called. Also, it does not support Maps where
different keys point to equal values.

This new test and its failure demonstrates how nextVal() is
incompatible with Maps which have multiple keys pointing to strictly
equal values.